### PR TITLE
Added: Support for Specifying Pre-Uninstall Script

### DIFF
--- a/PupNet.Test/BuildHostIntegrationTest.cs
+++ b/PupNet.Test/BuildHostIntegrationTest.cs
@@ -214,7 +214,7 @@ public class BuildHostIntegrationTest
                 lines.Add($"{nameof(RpmAutoProv)} = false");
 
                 lines.Add($"{nameof(SetupVersionOutput)} = true");
-                lines.Add($"{nameof(SetupUninstallCommand)} = uninstall.bat");
+                lines.Add($"{nameof(SetupUninstallScript)} = uninstall.bat");
                 lines.Add($"{nameof(SetupCommandPrompt)} = Command Prompt");
 
                 // Need to create dummy icons in order to get the thing to build (we cheat with dummy files).

--- a/PupNet.Test/BuildHostIntegrationTest.cs
+++ b/PupNet.Test/BuildHostIntegrationTest.cs
@@ -214,6 +214,7 @@ public class BuildHostIntegrationTest
                 lines.Add($"{nameof(RpmAutoProv)} = false");
 
                 lines.Add($"{nameof(SetupVersionOutput)} = true");
+                lines.Add($"{nameof(SetupUninstallCommand)} = uninstall.bat");
                 lines.Add($"{nameof(SetupCommandPrompt)} = Command Prompt");
 
                 // Need to create dummy icons in order to get the thing to build (we cheat with dummy files).

--- a/PupNet.Test/ConfigurationReaderTest.cs
+++ b/PupNet.Test/ConfigurationReaderTest.cs
@@ -344,8 +344,8 @@ public class ConfigurationReaderTest
     [Fact]
     public void UninstallCommand_String_IsValid()
     {
-        Assert.NotNull(Create().SetupUninstallCommand);
-        Assert.NotNull(Create(nameof(ConfigurationReader.SetupUninstallCommand)).SetupUninstallCommand);
+        Assert.NotNull(Create().SetupUninstallScript);
+        Assert.NotNull(Create(nameof(ConfigurationReader.SetupUninstallScript)).SetupUninstallScript);
     }
 
     [Fact]

--- a/PupNet.Test/ConfigurationReaderTest.cs
+++ b/PupNet.Test/ConfigurationReaderTest.cs
@@ -340,6 +340,13 @@ public class ConfigurationReaderTest
         Assert.True(Create().SetupVersionOutput);
         Assert.False(Create(nameof(ConfigurationReader.SetupVersionOutput)).SetupVersionOutput);
     }
+    
+    [Fact]
+    public void UninstallCommand_String_IsValid()
+    {
+        Assert.NotNull(Create().SetupUninstallCommand);
+        Assert.NotNull(Create(nameof(ConfigurationReader.SetupUninstallCommand)).SetupUninstallCommand);
+    }
 
     [Fact]
     public void ToString_VisualInspection()

--- a/PupNet.Test/DummyConf.cs
+++ b/PupNet.Test/DummyConf.cs
@@ -104,6 +104,7 @@ public class DummyConf : ConfigurationReader
         lines.Add($"{nameof(SetupSignTool)} = {ExpectSignTool}");
         lines.Add($"{nameof(SetupSuffixOutput)} = Setup");
         lines.Add($"{nameof(SetupVersionOutput)} = true");
+        lines.Add($"{nameof(SetupUninstallCommand)} = uninstall.bat");
 
         Remove(lines, omit);
 

--- a/PupNet.Test/DummyConf.cs
+++ b/PupNet.Test/DummyConf.cs
@@ -104,7 +104,7 @@ public class DummyConf : ConfigurationReader
         lines.Add($"{nameof(SetupSignTool)} = {ExpectSignTool}");
         lines.Add($"{nameof(SetupSuffixOutput)} = Setup");
         lines.Add($"{nameof(SetupVersionOutput)} = true");
-        lines.Add($"{nameof(SetupUninstallCommand)} = uninstall.bat");
+        lines.Add($"{nameof(SetupUninstallScript)} = uninstall.bat");
 
         Remove(lines, omit);
 

--- a/PupNet.sln
+++ b/PupNet.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PupNet", "PupNet\PupNet.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PupNet.Test", "PupNet.Test\PupNet.Test.csproj", "{F43CAFE1-8212-406C-80A5-13F104F7467B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solutionFiles", ".solutionFiles", "{655EB92C-F08C-4992-BC36-28D375C0EE49}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/PupNet/Builders/SetupBuilder.cs
+++ b/PupNet/Builders/SetupBuilder.cs
@@ -269,9 +269,10 @@ public class SetupBuilder : PackageBuilder
         sb.AppendLine("Type: filesandordirs; Name: \"{group}\\*\";");
         sb.AppendLine();
         sb.AppendLine("[UninstallRun]");
-        if (!string.IsNullOrEmpty(Configuration.SetupUninstallCommand))
+        if (!string.IsNullOrEmpty(Configuration.SetupUninstallScript))
         {
-            sb.AppendLine($"Filename: \"{Configuration.SetupUninstallCommand}\"; Flags: runhidden");
+            string uninstallScriptPath = $"{{app}}\\{Configuration.SetupUninstallScript}";
+            sb.AppendLine($"Filename: \"{uninstallScriptPath}\"; Flags: runhidden shellexec waituntilterminated");
         }
         sb.AppendLine();
         sb.AppendLine("[UninstallDelete]");

--- a/PupNet/Builders/SetupBuilder.cs
+++ b/PupNet/Builders/SetupBuilder.cs
@@ -269,6 +269,10 @@ public class SetupBuilder : PackageBuilder
         sb.AppendLine("Type: filesandordirs; Name: \"{group}\\*\";");
         sb.AppendLine();
         sb.AppendLine("[UninstallRun]");
+        if (!string.IsNullOrEmpty(Configuration.SetupUninstallCommand))
+        {
+            sb.AppendLine($"Filename: \"{Configuration.SetupUninstallCommand}\"; Flags: runhidden");
+        }
         sb.AppendLine();
         sb.AppendLine("[UninstallDelete]");
         sb.AppendLine("Type: dirifempty; Name: \"{app}\"");

--- a/PupNet/Builders/SetupBuilder.cs
+++ b/PupNet/Builders/SetupBuilder.cs
@@ -272,7 +272,7 @@ public class SetupBuilder : PackageBuilder
         if (!string.IsNullOrEmpty(Configuration.SetupUninstallScript))
         {
             string uninstallScriptPath = $"{{app}}\\{Configuration.SetupUninstallScript}";
-            sb.AppendLine($"Filename: \"{uninstallScriptPath}\"; Flags: runhidden shellexec waituntilterminated");
+            sb.AppendLine($"Filename: \"{uninstallScriptPath}\"; Flags: runhidden waituntilterminated");
         }
         sb.AppendLine();
         sb.AppendLine("[UninstallDelete]");

--- a/PupNet/ConfigurationReader.cs
+++ b/PupNet/ConfigurationReader.cs
@@ -78,6 +78,7 @@ public class ConfigurationReader
             SetupCommandPrompt = "Command Prompt";
             SetupSuffixOutput = "Setup";
             SetupVersionOutput = true;
+            SetupUninstallCommand = "uninstall.bat";
         }
 
         if (!string.IsNullOrEmpty(metabase))
@@ -183,6 +184,7 @@ public class ConfigurationReader
         SetupSignTool = GetOptional(nameof(SetupSignTool), ValueFlags.None);
         SetupSuffixOutput = GetOptional(nameof(SetupSuffixOutput), ValueFlags.SafeNoSpace);
         SetupVersionOutput = GetBool(nameof(SetupVersionOutput), SetupVersionOutput);
+        SetupUninstallCommand = GetOptional(nameof(SetupUninstallCommand), ValueFlags.None);
 
         // Not actually a key-value, but a comment
         PupnetVersion = ExtractVersion(reader.ToString());
@@ -281,6 +283,7 @@ public class ConfigurationReader
     public string? SetupSignTool { get; }
     public string? SetupSuffixOutput { get; }
     public bool SetupVersionOutput { get; }
+    public string? SetupUninstallCommand { get; }
 
     public string? PupnetVersion { get; }
 
@@ -635,6 +638,13 @@ public class ConfigurationReader
                 $"Boolean (true or false) which sets whether to include the application version in the setup filename,",
                 $"i.e. 'HelloWorld-1.2.3-x86_64.exe'. Default is false. Ignored if the output filename is specified",
                 $"at command line."));
+        
+        sb.Append(CreateHelpField(nameof(SetupUninstallCommand), SetupUninstallCommand, style,
+            $"Optional path and arguments to an additional file that should be executed before uninstall.",
+            $"The command is executed at the installation path of your application.",
+            $"This binds to the `[UninstallRun]` section of InnoSetup.",
+            $"This is useful if your application has non-static configurable storage locations for data.",
+            $"Example: HelloWorld.exe --uninstall"));
 
         return sb.ToString().Trim().ReplaceLineEndings("\n");
     }

--- a/PupNet/ConfigurationReader.cs
+++ b/PupNet/ConfigurationReader.cs
@@ -78,7 +78,7 @@ public class ConfigurationReader
             SetupCommandPrompt = "Command Prompt";
             SetupSuffixOutput = "Setup";
             SetupVersionOutput = true;
-            SetupUninstallCommand = "uninstall.bat";
+            SetupUninstallScript = "uninstall.bat";
         }
 
         if (!string.IsNullOrEmpty(metabase))
@@ -184,7 +184,7 @@ public class ConfigurationReader
         SetupSignTool = GetOptional(nameof(SetupSignTool), ValueFlags.None);
         SetupSuffixOutput = GetOptional(nameof(SetupSuffixOutput), ValueFlags.SafeNoSpace);
         SetupVersionOutput = GetBool(nameof(SetupVersionOutput), SetupVersionOutput);
-        SetupUninstallCommand = GetOptional(nameof(SetupUninstallCommand), ValueFlags.None);
+        SetupUninstallScript = GetOptional(nameof(SetupUninstallScript), ValueFlags.None);
 
         // Not actually a key-value, but a comment
         PupnetVersion = ExtractVersion(reader.ToString());
@@ -283,7 +283,7 @@ public class ConfigurationReader
     public string? SetupSignTool { get; }
     public string? SetupSuffixOutput { get; }
     public bool SetupVersionOutput { get; }
-    public string? SetupUninstallCommand { get; }
+    public string? SetupUninstallScript { get; }
 
     public string? PupnetVersion { get; }
 
@@ -639,12 +639,13 @@ public class ConfigurationReader
                 $"i.e. 'HelloWorld-1.2.3-x86_64.exe'. Default is false. Ignored if the output filename is specified",
                 $"at command line."));
         
-        sb.Append(CreateHelpField(nameof(SetupUninstallCommand), SetupUninstallCommand, style,
-            $"Optional path and arguments to an additional file that should be executed before uninstall.",
-            $"The command is executed at the installation path of your application.",
+        sb.Append(CreateHelpField(nameof(SetupUninstallScript), SetupUninstallScript, style,
+            $"Optional name of a script to run before uninstall.",
+            $"This is script file relative to the directory of the application and must have a default file association.",
             $"This binds to the `[UninstallRun]` section of InnoSetup.",
-            $"This is useful if your application has non-static configurable storage locations for data.",
-            $"Example: HelloWorld.exe --uninstall"));
+            $"From this script, you may want to run your application, which is very useful if ",
+            $"your application has non-static configurable storage locations for data.",
+            $"Example: uninstall.bat"));
 
         return sb.ToString().Trim().ReplaceLineEndings("\n");
     }

--- a/README.md
+++ b/README.md
@@ -1347,13 +1347,14 @@ Type `pupnet --help conf` to see supported configuration reference information:
     at command line.
     Example: SetupVersionOutput = true
 
-    ** SetupUninstallCommand **
-    Optional path and arguments to an additional file that should be executed before uninstall.
-    The command is executed at the installation path of your application.
+    ** SetupUninstallScript **
+    Optional name of a script to run before uninstall.
+    This is script file relative to the directory of the application and must have a default file association.
     This binds to the `[UninstallRun]` section of InnoSetup.
-    This is useful if your application has non-static configurable storage locations for data.
+    From this script, you may want to run your application, which is very useful if 
+    your application has non-static configurable storage locations for data.
 
-    Example: HelloWorld.exe --uninstall
+    Example: uninstall.bat
 
 ## FAQs & GOTCHAS <a name="faqs-gotchas"/>
 

--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,14 @@ Type `pupnet --help conf` to see supported configuration reference information:
     at command line.
     Example: SetupVersionOutput = true
 
+    ** SetupUninstallCommand **
+    Optional path and arguments to an additional file that should be executed before uninstall.
+    The command is executed at the installation path of your application.
+    This binds to the `[UninstallRun]` section of InnoSetup.
+    This is useful if your application has non-static configurable storage locations for data.
+
+    Example: HelloWorld.exe --uninstall
+
 ## FAQs & GOTCHAS <a name="faqs-gotchas"/>
 
 ### NETSDK1194: The "--output" option isn't supported <a name="NETSDK1194"/>


### PR DESCRIPTION
## Summary

This PR adds the ability to specify a script that will be executed as a pre-uninstall step when the application is uninstalled via the InnoSetup generated Windows installer.

![image](https://github.com/kuiperzone/PupNet-Deploy/assets/6697380/e38afb29-b6d7-4b87-9620-c9b6e671b767)

An example test callback I made with my work project. (RIP Emoji)

## Purpose

Certain kinds of applications require custom cleanup logic for deleting leftover files left behind when a program is removed.
This is common in applications that allow a person to specify custom locations for storing user data.

A common, universally understood example is `Steam`. In `Steam` you can add additional storage locations where you want your games to be stored. For example, on a secondary HDD or SSD.

In other situations, you may also want your application to perform an additional series of steps (for example, undo external changes) made to data outside of the Application folder. Think of programs that 'patch' external components, for example `ExplorerPatcher`.

As this sort of logic cannot always be statically declared ahead of time, a 'hook-in' system is required to perform cleanup steps on uninstall.

## Key Changes

- Added a new `SetupUninstallScript` configuration option which specifies a path to a script file relative to the application directory. 
    - Any file can be specified, as long as the extension has an association.
    - Though I personally recommend batch files `.bat`, as just about every Windows system will support them.

- The `SetupUninstallScript` is executed from the uninstall wizard before rest of the uninstallation continues. 
- The uninstall script is invoked via the `[UninstallRun]` section in the generated InnoSetup script.

In addition:
- Updated the README and CLI example  help with documentation for the new `SetupUninstallScript` option.
- Added misc. test code for the new variable.
    - Tested like the other config variables, and not much more. 

## Design Motivations

I have decided to limit this to a file name, with no escape / quotes for the time being.
This is in order to keep things simple, for both us and the end user.

Some Related Ramblings Below.

------------

I've originally implemented this to work such that you could specify a full commandline to execute, for instance `YourApp.exe --uninstall-app`. However I wound up stepping back from that design for the time being due to concerns around parameter quoting and testing.

In particular, splitting up an input into a parameter array is non-trivial, there is a lot of additional mental complexity involved.
For example, say the user has a space in their app name and wants to run `"Your App.exe" --uninstall-app`. Because many of the existing fields say 'this maps to X in InnoSetup' it is unclear to the user if:

- You should use `InnoSetup`'s escaping style `""Your App.exe"" --uninstall-app` (escape with `"`).
    - In which case part of InnoSetup `leaks` through the PupNet abstraction.
- You should use .NET escaping style. `\"Your App.exe\"`.
- You should not escape at all.

Unfortunately, for better or worse, the answer here is, inconsistent.
The custom `ini` parser in PupNet strips the quotes by default if the value starts with a quote. So you might wind up with something like this being valid `YourApp.exe "Some Folder"`; but if the EXE name has a space, you suddenly have to add a second set of quotes like `""Your App.exe" "Some Folder""`.

This unfortunately creates inconsistency and might lead to frustrating users. 

So I decided to keep it simple, point to a script and let a script handle it for the time being.
This also makes things potentially easier to test for some niche use cases.

Support for a commandline could still be added in the future, either directly in the current field, or in a separate field.
It is just that a more in-depth design would probably be required there.

-------------

In any case, if anything else is missing here, let me know.