### PR TITLE
Feature: Add MSI packaging support.

### DIFF
--- a/KuiperZone.PupNet.Test/DummyConf.cs
+++ b/KuiperZone.PupNet.Test/DummyConf.cs
@@ -107,6 +107,20 @@ public class DummyConf : ConfigurationReader
         lines.Add($"{nameof(SetupVersionOutput)} = true");
         lines.Add($"{nameof(SetupUninstallScript)} = uninstall.bat");
 
+        lines.Add($"{nameof(MsiUuid)} = 2754bd46-1ef3-467b-b72a-aaa778a62bbb");
+        lines.Add($"{nameof(MsiMachineInstall)} = true");
+        lines.Add($"{nameof(MsiSuffixOutput)} = Install");
+        lines.Add($"{nameof(MsiVersionOutput)} = true");
+        lines.Add($"{nameof(MsiCodeSignCertName)} = \"MyCert.pfx\"");
+        lines.Add($"{nameof(MsiCodeSignCertPassword)} = \"v3rys3cur3\"");
+        lines.Add($"{nameof(MsiCodeSignDescription)} = \"MyCompany MyApp\"");
+        lines.Add($"{nameof(MsiCodeSignStore)} = pfx");
+        lines.Add($"{nameof(MsiCodeSignAlgorithm)} = sha256");
+        lines.Add($"{nameof(MsiCodeSignTimestampUrl)} = \"http://timestamp.sectigo.com\"");
+        lines.Add($"{nameof(MsiCodeSignEmbedded)} = true");
+        lines.Add($"{nameof(MsiSignToolLocation)} = \"C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64/\"");
+        lines.Add($"{nameof(MsiSignToolExtraArguments)} = \"/sm\"");
+
         Remove(lines, omit);
 
         return lines.ToArray();

--- a/KuiperZone.PupNet.Test/PackageBuilderTest.cs
+++ b/KuiperZone.PupNet.Test/PackageBuilderTest.cs
@@ -116,6 +116,20 @@ public class PackageBuilderTest
     }
 
     [Fact]
+    public void Msi_DecodesOK()
+    {
+        var builder = new MsiBuilder(new DummyConf());
+
+        Assert.False(builder.IsLinuxExclusive);
+        Assert.True(builder.IsWindowsExclusive);
+        AssertOK(builder, PackageKind.Msi);
+        Assert.Null(builder.MetaBuildPath);
+
+        Assert.StartsWith("HelloWorldInstall-5.4.3-2.", builder.OutputName);
+        Assert.EndsWith(".msi", builder.OutputName);
+    }
+
+    [Fact]
     public void Zip_DecodesOK()
     {
         var builder = new ZipBuilder(new DummyConf());

--- a/KuiperZone.PupNet/BuilderFactory.cs
+++ b/KuiperZone.PupNet/BuilderFactory.cs
@@ -37,6 +37,7 @@ public class BuilderFactory
             case PackageKind.Rpm: return new RpmBuilder(conf);
             case PackageKind.Deb: return new DebianBuilder(conf);
             case PackageKind.Setup: return new SetupBuilder(conf);
+            case PackageKind.Msi: return new MsiBuilder(conf);
             case PackageKind.Zip: return new ZipBuilder(conf);
             default: throw new ArgumentException($"Invalid or unsupported {nameof(PackageKind)} {conf.Arguments.Kind}");
         }

--- a/KuiperZone.PupNet/BuilderFactory.cs
+++ b/KuiperZone.PupNet/BuilderFactory.cs
@@ -37,6 +37,7 @@ public class BuilderFactory
             case PackageKind.Rpm: return new RpmBuilder(conf);
             case PackageKind.Deb: return new DebianBuilder(conf);
             case PackageKind.Setup: return new SetupBuilder(conf);
+            case PackageKind.Msi: return new MsiBuilder();
             case PackageKind.Zip: return new ZipBuilder(conf);
             default: throw new ArgumentException($"Invalid or unsupported {nameof(PackageKind)} {conf.Arguments.Kind}");
         }

--- a/KuiperZone.PupNet/Builders/MsiBuilder.cs
+++ b/KuiperZone.PupNet/Builders/MsiBuilder.cs
@@ -222,6 +222,7 @@ public class MsiBuilder : PackageBuilder
         // Just a constant namespace for generating the MSI UUID so that it's stable across builds
         // If this is ever changed and the user doesn't provide their own UUID, it will result in a different
         // product code and thus a different installation.
+        // This is also the UUID used by PupNet in all demos/examples for itself.
         const string NAMESPACE = "2754bd46-1ef3-467b-b72a-aaa778a62bbb";
 
         return Configuration.MsiUuid ?? 

--- a/KuiperZone.PupNet/Builders/MsiBuilder.cs
+++ b/KuiperZone.PupNet/Builders/MsiBuilder.cs
@@ -1,0 +1,57 @@
+﻿// -----------------------------------------------------------------------------
+// PROJECT   : PupNet
+// COPYRIGHT : Andy Thomas (C) 2022-26
+// LICENSE   : AGPL-3.0-or-later
+// HOMEPAGE  : https://github.com/kuiperzone/PupNet
+//
+// PupNet is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// PupNet is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with PupNet. If not, see <https://www.gnu.org/licenses/>.
+// -----------------------------------------------------------------------------
+
+// MsiBuilder created by Julian Rossbach.
+
+namespace KuiperZone.PupNet.Builders;
+
+/// <summary>
+/// Extends <see cref="PackageBuilder"/> for MSI package.
+/// Leverages SimpleMSI.
+/// </summary>
+public class MsiBuilder : PackageBuilder
+{
+    private const string PromptBat = "CommandPrompt.bat";
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public MsiBuilder(ConfigurationReader conf)
+        : base(conf, PackageKind.Msi)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string PackageArch => throw new NotImplementedException();
+
+    public override string OutputName => throw new NotImplementedException();
+
+    public override string BuildAppBin => throw new NotImplementedException();
+
+    public override string InstallBin => throw new NotImplementedException();
+
+    public override string? ManifestContent => throw new NotImplementedException();
+
+    public override string? ManifestBuildPath => throw new NotImplementedException();
+
+    public override IReadOnlyCollection<string> PackageCommands => throw new NotImplementedException();
+
+    public override bool SupportsStartCommand => throw new NotImplementedException();
+
+    public override bool SupportsPostRun => throw new NotImplementedException();
+}

--- a/KuiperZone.PupNet/Builders/MsiBuilder.cs
+++ b/KuiperZone.PupNet/Builders/MsiBuilder.cs
@@ -16,7 +16,7 @@
 // with PupNet. If not, see <https://www.gnu.org/licenses/>.
 // -----------------------------------------------------------------------------
 
-// MsiBuilder created by Julian Rossbach.
+// MsiBuilder created by Julian Rossbach (httpS://github.com/Juff-Ma).
 
 namespace KuiperZone.PupNet.Builders;
 
@@ -26,32 +26,52 @@ namespace KuiperZone.PupNet.Builders;
 /// </summary>
 public class MsiBuilder : PackageBuilder
 {
-    private const string PromptBat = "CommandPrompt.bat";
-
     /// <summary>
     /// Constructor.
     /// </summary>
     public MsiBuilder(ConfigurationReader conf)
         : base(conf, PackageKind.Msi)
     {
-        throw new NotImplementedException();
+        BuildAppBin = Path.Combine(BuildRoot, "Publish");
+
+        // SimpleMSI automatically installs to Program Files/LocalAppData
+        // also user can define during installation
+        InstallBin = "";
+
+        ManifestBuildPath = Path.Combine(Root, Configuration.AppBaseName + ".msi.toml");
+        // TODO: set ManifestContent based on configuration
+
+        // TODO: set PackageCommands based on configuration
     }
 
-    public override string PackageArch => throw new NotImplementedException();
+    public override string PackageArch
+    {
+        get
+        {
+            if (Arguments.Arch != null)
+            {
+                return Arguments.Arch;
+            }
 
-    public override string OutputName => throw new NotImplementedException();
+            // This works for everything besides Arm32, which current .NET does not support anyway
+            return Runtime.BuildArch.ToString().ToLowerInvariant(); 
+        }
+    }
 
-    public override string BuildAppBin => throw new NotImplementedException();
+    public override string OutputName => GetOutputName(Configuration.MsiVersionOutput, Configuration.MsiSuffixOutput,
+                                                        PackageArch, ".msi");
 
-    public override string InstallBin => throw new NotImplementedException();
+    public override string BuildAppBin { get; }
 
-    public override string? ManifestContent => throw new NotImplementedException();
+    public override string InstallBin { get; }
 
-    public override string? ManifestBuildPath => throw new NotImplementedException();
+    public override string? ManifestContent { get; }
 
-    public override IReadOnlyCollection<string> PackageCommands => throw new NotImplementedException();
+    public override string? ManifestBuildPath { get; }
 
-    public override bool SupportsStartCommand => throw new NotImplementedException();
+    public override IReadOnlyCollection<string> PackageCommands { get; }
 
-    public override bool SupportsPostRun => throw new NotImplementedException();
+    public override bool SupportsStartCommand => true;
+
+    public override bool SupportsPostRun => false;
 }

--- a/KuiperZone.PupNet/ConfigurationReader.cs
+++ b/KuiperZone.PupNet/ConfigurationReader.cs
@@ -85,7 +85,6 @@ public class ConfigurationReader
             SetupUninstallScript = "uninstall.bat";
             MsiUuid = "cdd3abd4-3076-4d81-b531-339d7ad8b320";
             MsiMachineInstall = true;
-            MsiCommandPrompt = "MSI Command Prompt";
             MsiSuffixOutput = "Install";
             MsiVersionOutput = true;
             MsiCodeSignCertName = "MyCert.pfx";
@@ -207,7 +206,6 @@ public class ConfigurationReader
 
         MsiUuid = GetOptional(nameof(MsiUuid), ValueFlags.StrictSafe); // StrictSafe isn't necessarily meant for this but should work fine ig
         MsiMachineInstall = GetBool(nameof(MsiMachineInstall), SetupAdminInstall); // Usually MSIs are installed Machine wide by default, however we already have the option so reuse it
-        MsiCommandPrompt = GetOptional(nameof(MsiCommandPrompt), ValueFlags.Safe) ?? SetupCommandPrompt;
         MsiSuffixOutput = GetOptional(nameof(MsiSuffixOutput), ValueFlags.SafeNoSpace) ?? SetupSuffixOutput;
         MsiVersionOutput = GetBool(nameof(MsiVersionOutput), SetupVersionOutput);
         MsiHideProgramEntry = GetBool(nameof(MsiHideProgramEntry), MsiHideProgramEntry);
@@ -331,7 +329,6 @@ public class ConfigurationReader
 
     public string? MsiUuid { get; } // Uniquely identifies an MSI product, will be generated based on AppId if left unset.
     public bool MsiMachineInstall { get; }
-    public string? MsiCommandPrompt { get; }
     public string? MsiSuffixOutput { get; }
     public bool MsiVersionOutput { get; }
     public bool MsiHideProgramEntry { get; }
@@ -737,10 +734,6 @@ public class ConfigurationReader
                 $"Boolean (true or false) which specifies whether to install the application for all users (machine),",
                 $"or just the current user. Default is false (per-user). Although machine installation is more common.", $"" +
                 $"If {nameof(SetupAdminInstall)} is set but this isn't, then it will determine this too."));
-
-        sb.Append(CreateHelpField(nameof(MsiCommandPrompt), MsiCommandPrompt, style,
-                $"Same as {nameof(SetupCommandPrompt)} but for MSI.",
-                $"Will default to {nameof(SetupCommandPrompt)} if unset."));
 
         sb.Append(CreateHelpField(nameof(MsiSuffixOutput), MsiSuffixOutput, style,
                 $"Same as {nameof(SetupSuffixOutput)} but for MSI.",

--- a/KuiperZone.PupNet/ConfigurationReader.cs
+++ b/KuiperZone.PupNet/ConfigurationReader.cs
@@ -83,7 +83,7 @@ public class ConfigurationReader
             SetupSuffixOutput = "Setup";
             SetupVersionOutput = true;
             SetupUninstallScript = "uninstall.bat";
-            MsiUuid = "cdd3abd4-3076-4d81-b531-339d7ad8b320";
+            MsiUuid = "2754bd46-1ef3-467b-b72a-aaa778a62bbb";
             MsiMachineInstall = true;
             MsiSuffixOutput = "Install";
             MsiVersionOutput = true;
@@ -91,6 +91,7 @@ public class ConfigurationReader
             MsiCodeSignCertPassword = "v3rys3cur3";
             MsiCodeSignDescription = "MyCompany MyApp";
             MsiCodeSignStore = "pfx";
+            MsiCodeSignAlgorithm = "sha256";
             MsiCodeSignTimestampUrl = "http://timestamp.acs.microsoft.com";
             MsiCodeSignEmbedded = true;
             MsiSignToolLocation = "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64\\";

--- a/KuiperZone.PupNet/ConfigurationReader.cs
+++ b/KuiperZone.PupNet/ConfigurationReader.cs
@@ -213,6 +213,7 @@ public class ConfigurationReader
         MsiCodeSignCertPassword = GetOptional(nameof(MsiCodeSignCertPassword), ValueFlags.None);
         MsiCodeSignDescription = GetOptional(nameof(MsiCodeSignDescription), ValueFlags.Safe);
         MsiCodeSignStore = GetOptional(nameof(MsiCodeSignStore), ValueFlags.SafeNoSpace);
+        MsiCodeSignAlgorithm = GetOptional(nameof(MsiCodeSignAlgorithm), ValueFlags.SafeNoSpace);
         MsiCodeSignTimestampUrl = GetOptional(nameof(MsiCodeSignTimestampUrl), ValueFlags.SafeNoSpace);
         MsiCodeSignEmbedded = GetBool(nameof(MsiCodeSignEmbedded), MsiCodeSignEmbedded);
         MsiSignToolLocation = GetOptional(nameof(MsiSignToolLocation), ValueFlags.Safe);
@@ -337,6 +338,7 @@ public class ConfigurationReader
     public string? MsiCodeSignCertPassword { get; }
     public string? MsiCodeSignDescription { get; }
     public string? MsiCodeSignStore { get; } 
+    public string? MsiCodeSignAlgorithm { get; }
     public string? MsiCodeSignTimestampUrl { get; }
     public bool MsiCodeSignEmbedded { get; }
     public string? MsiSignToolLocation { get; }
@@ -757,6 +759,9 @@ public class ConfigurationReader
         sb.Append(CreateHelpField(nameof(MsiCodeSignStore), MsiCodeSignStore, style,
             $"This determines where to find the certificate.",
             $"May be 'pfx' for PFX files, 'name' for common name ID or 'sha1' for their hash ID."));
+        sb.Append(CreateHelpField(nameof(MsiCodeSignAlgorithm), MsiCodeSignAlgorithm, style,
+            $"This determines the certificate hashing algorithm.",
+            $"'sha256' by default or optionally 'sha1'."));
         sb.Append(CreateHelpField(nameof(MsiCodeSignTimestampUrl), MsiCodeSignTimestampUrl, style,
             $"URL of the timestamp server to use when code signing the MSI.",
             "If you omit this, signing will still work but Windows might refuse your certificate after it expires."));

--- a/KuiperZone.PupNet/FileOps.cs
+++ b/KuiperZone.PupNet/FileOps.cs
@@ -200,6 +200,29 @@ public class FileOps(string? root = null)
     }
 
     /// <summary>
+    /// Reads file content. Returns null if path is null.
+    /// </summary>
+    public string? ReadFile(string? path)
+    {
+        if (!string.IsNullOrEmpty(path))
+        {
+            try
+            {
+                Write("Reading File: ", path);
+                var content =  File.ReadAllText(path);
+                WriteLine(" ... OK");
+                return content;
+            }
+            catch
+            {
+                WriteLine(" ... FAILED");
+                throw;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Zips the directory and writes to output.
     /// </summary>
     public void Zip(string? directory, string? output)

--- a/KuiperZone.PupNet/KuiperZone.PupNet.csproj
+++ b/KuiperZone.PupNet/KuiperZone.PupNet.csproj
@@ -17,7 +17,7 @@
 		<Authors>Andy Thomas</Authors>
 		<Copyright>© Andy Thomas 2022-25</Copyright>
 		<Company>KuiperZone</Company>
-		<Description>Publish, Package and Deploy as: AppImage, Windows Setup, Flatpak, Deb, RPM and Zip</Description>
+		<Description>Publish, Package and Deploy as: AppImage, Windows Setup, MSI, Flatpak, Deb, RPM and Zip</Description>
 		<PackageTags>publish;pack;deploy;AppImage;flatpak;deb;rpm;setup;installer;linux;</PackageTags>
 		<Language>en-US</Language>
 		<PackageProjectUrl>https://github.com/kuiperzone/PupNet-Deploy</PackageProjectUrl>

--- a/KuiperZone.PupNet/PackageKind.cs
+++ b/KuiperZone.PupNet/PackageKind.cs
@@ -54,6 +54,11 @@ public enum PackageKind
     /// Setup file. Windows only.
     /// </summary>
     Setup,
+
+    /// <summary>
+    /// Windows Installer. Windows only.
+    /// </summary>
+    Msi,
 }
 
 /// <summary>
@@ -74,6 +79,7 @@ public static class DeployKindExtension
             case PackageKind.Rpm: return ".rpm";
             case PackageKind.Flatpak: return ".flatpak";
             case PackageKind.Setup: return ".exe";
+            case PackageKind.Msi: return ".msi";
             default: throw new ArgumentException($"Invalid {nameof(PackageKind)} {kind}");
         }
     }
@@ -101,7 +107,7 @@ public static class DeployKindExtension
     /// </summary>
     public static bool TargetsWindows(this PackageKind kind, bool exclusive = false)
     {
-        if (kind == PackageKind.Zip || kind == PackageKind.Setup)
+        if (kind == PackageKind.Zip || kind == PackageKind.Setup || kind == PackageKind.Msi)
         {
             return !exclusive || (!TargetsLinux(kind) && !TargetsOsx(kind));
         }


### PR DESCRIPTION
For a while now I've been working on [SimpleMSI](https://github.com/Juff-Ma/SimpleMSI), a tool for creating MSIs simply from the command line based on WiX.

Since I'm also a fan of PupNet and MSI support was a thing I've been missing in it I've gone ahead and added support for building MSIs (funnily enough during the process I found some bugs in SimpleMSI as well and fixed them).

The MsiBuilder is based on SimpleMSI and therefore requires it (at least version 1.1.4) and WiX (theoretically >4 but only tested with 6) to work. There are some MSI specific options introduced, most of which are for the code signing process (which is different in SimpleMSI compared to Inno), duplicates from the SetupBuilder or a few (2) MSI specific options.

It should be noted that, by nature, MSI is more limited than custom setups by default (unless using custom actions which SimpleMSI deliberately does not do) so some features like custom uninstall scripts or the command prompt are difficult or impossible (in the current state) to implement. However since both MSI and Setups are in their core very similar, as mentioned above the MSI builder duplicates some code roughly and also tries to behave as closely to the setup one as possible.

This *could* also be a starting ground for #17 since Microsoft provides official tools for converting MSIs to MSIX.

So far I've tested both AvantGarde as well as PupNet as a base for feature completeness and they both package and install just fine.

Of course I'm happy to answer any questions regarding the MSI support and look into issues that might come up.

Edit: I'm pretty sure this is implied but please point out if I've made any mistakes that impact the functionality of other parts of PupNet.